### PR TITLE
update way plugin is loaded

### DIFF
--- a/README
+++ b/README
@@ -26,7 +26,7 @@ INSTALL
         make install
 
         # Enable this plugin in your RT_SiteConfig.pm:
-        Set(@Plugins, (qw/RT::Extension::TimeWorkedReport/) );
+        Plugin('RT::Extension::TimeWorkedReport');
 
         After restarting RT the TimeWorkedReport will be available under the Tools menu.
 


### PR DESCRIPTION
this is the way I'm loading all my plugins in RT. I think it didn't work in the way it appears in documentation

https://gitlab.com/guifi-exo/wiki/blob/master/howto/request-tracker.md#install

as appears here https://github.com/coffeemonster/RT-Extension-TimeWorkedReport/blob/master/lib/RT/Extension/TimeWorkedReport.pm#L56

and the idea is that also here gets updated https://metacpan.org/pod/RT::Extension::TimeWorkedReport